### PR TITLE
feat: Add to i18n dictionary without fetch

### DIFF
--- a/src/services/i18n.js
+++ b/src/services/i18n.js
@@ -32,7 +32,7 @@ class I18n {
     this._localeId = DEFAULT_LOCALE
     this._observer = null
     this._dictionary = new Map()
-    this._loadBasePath = window.location.href
+    this._loadBasePath = window.location.origin
     this._loadPath = ''
     this._storageKey = 'i18nLocale'
     this._urlParamKey = 'locale'
@@ -40,7 +40,7 @@ class I18n {
   }
 
   config({attributeMap, decorators, loadBasePath, loadPath, storageKey, urlParam}) {
-    this._loadBasePath = loadBasePath || window.location.href
+    this._loadBasePath = loadBasePath || window.location.origin
     this._loadPath = loadPath || ''
     this._storageKey = storageKey || 'i18nLocale'
     this._urlParamKey = urlParam || 'locale'
@@ -58,6 +58,17 @@ class I18n {
         }
       })
     }
+  }
+
+  addDictionary(localeId, dictionary) {
+    if(localeId && dictionary) {
+      this.dictionary.set(localeId, dictionary)
+    }
+    return this
+  }
+
+  get dictionary() {
+    return this._dictionary
   }
 
   get localeId() {
@@ -129,7 +140,7 @@ class I18n {
 
     this._pending = new Promise(resolve => {
       let translator = this._translator.bind(this)
-      if (!this._dictionary.get(this.localeId)) {
+      if (!this.dictionary.get(this.localeId)) {
         fetch(this.loadPath)
           .then(response => {
             if (response instanceof Response && response.ok) {
@@ -141,7 +152,7 @@ class I18n {
           .then(response => response.clone().json().catch(() => null))
           .then(responseJSON => {
             if (null !== responseJSON) {
-              this._dictionary.set(this.localeId, responseJSON)
+              this.dictionary.set(this.localeId, responseJSON)
             } else {
               throw new Error()
             }
@@ -168,7 +179,7 @@ class I18n {
   }
 
   _translator(i18nKey) {
-    const dictionary = this._dictionary.get(this.localeId)
+    const dictionary = this.dictionary.get(this.localeId)
     // Replace with Object.hasOwn() when Safari has support
     return dictionary && Object.prototype.hasOwnProperty.call(dictionary, i18nKey) ? dictionary[i18nKey] : i18nKey
   }

--- a/test/unit/services/i18n.test.js
+++ b/test/unit/services/i18n.test.js
@@ -20,6 +20,7 @@ describe('I18nService', () => {
       .withArgs(URLFail).and.returnValue(Promise.resolve(resFail));
 
     I18nService.localeId = I18nService.DEFAULT_LOCALE
+    I18nService.setLocale(I18nService.localeId)
   })
 
   afterAll(() => {
@@ -182,6 +183,11 @@ describe('I18nService', () => {
       const translator = await I18nService.setLocale('ek')
       const message = translator('test')
       expect(message).toEqual('A thing')
+    })
+
+    it('should add to the dictionary without the use of fetch', async () => {
+      I18nService.addDictionary('fr', {"test" : "essai"})
+      expect(I18nService.dictionary.has('fr')).toBeTrue()
     })
 
   })


### PR DESCRIPTION
<!--
  Before issuing a pull request:

  - Please read our contribution guidelines, especially the section on Pull Requests.
  - Please first create an issue (https://github.com/johnsonandjohnson/mettle-components/issues/new/choose). All pull requests must be linked to an issue.
-->

<!--
  IMPORTANT
  
  The pull request title will become the commit message title at merge, and
  should adhere to Conventional Commit Message Conventions. for details and examples.
-->

## Changes
<!-- Brief description of the changes introduced by this PR -->
- Allow the dictionary map to be updated without the use of fetch.
- Default path for locales uses location origin instead of href

## Related Issues
<!--
  Link to the issue that is fixed or resolved by this PR (if there is one)
  e.g. Fixes #1234, Closes #4567

  Link to an issue that is partially addressed by this PR (if there are any)
-->
Closes #27 

<!-- IF THIS PR INTRODUCES A BREAKING CHANGE

BREAKING CHANGE: Describe the nature of the breaking change here.

More Details about the breaking change.
-->
